### PR TITLE
Specify scope id in addresses to ping6

### DIFF
--- a/tests/netsh.sh
+++ b/tests/netsh.sh
@@ -76,7 +76,7 @@ configure_peers
 
 n1 wg set wg0 peer "$client_public" endpoint [::1]:2
 n2 wg set wg0 peer "$server_public" endpoint [::1]:1
-n2 ping6 -c 10 -f -W 1 fe80::
-n1 ping6 -c 10 -f -W 1 fe80::badc:0ffe:e0dd:f00d
+n2 ping6 -c 10 -f -W 1 fe80::%wg0
+n1 ping6 -c 10 -f -W 1 fe80::badc:0ffe:e0dd:f00d%wg0
 
 n1 ./wg-dynamic-server wg0


### PR DESCRIPTION
Without scope id, ping6 on a Debian 9 fails with

  connect: Invalid argument